### PR TITLE
Support for Regex replacements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapidpro_abtesting"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     {name = "IDEMS International", email = "contact@idems.international"},
 ]

--- a/testdata/RegexReplaceFlowNode.csv
+++ b/testdata/RegexReplaceFlowNode.csv
@@ -1,0 +1,2 @@
+"type_of_edit","flow_id","original_row_id","node_identifier","change","change:Stevefied","assign_to_group"
+"replace_bit_of_text","Flow_1",1,"Regex:.*","Regex:ood(.*message)","reat\1","FALSE"


### PR DESCRIPTION
The `change` column now may contain the prefix `regex:`. In this case, a regex search and replace is applied. You may use matching groups in the regex expression, and correspondingly `\1`, `\2`, ... to match those groups in the replacement string.

See `testdata/RegexReplaceFlowNode.csv` for an example.